### PR TITLE
fix: not resolve types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export default class KvStore<T extends SessionStoreData> implements Store {
 	 * The serializer to use.
 	 * @default JSON
 	 */
-	serializer: Serializer;
+	serializer: Serializer<T>;
 
 	/**
 	 * Time to live in milliseconds.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import type { SessionStoreData, Store } from 'svelte-kit-sessions';
 import type { KVNamespace } from '@cloudflare/workers-types';
 
-interface Serializer {
-	parse(s: string): SessionStoreData | Promise<SessionStoreData>;
-	stringify(data: SessionStoreData): string;
+interface Serializer<T extends SessionStoreData> {
+	parse(s: string): T | Promise<T>;
+	stringify(data: T): string;
 }
 
-interface KvStoreOptions {
+interface KvStoreOptions<T extends SessionStoreData> {
 	/**
 	 * An KVNamespace.
 	 */
@@ -20,7 +20,7 @@ interface KvStoreOptions {
 	 * The serializer to use.
 	 * @default JSON
 	 */
-	serializer?: Serializer;
+	serializer?: Serializer<T>;
 	/**
 	 * Time to live in milliseconds.
 	 * This ttl to be used if ttl is _Infinity_ when used from `svelte-kit-sessions`
@@ -31,8 +31,8 @@ interface KvStoreOptions {
 
 const ONE_DAY_IN_SECONDS = 86400;
 
-export default class KvStore implements Store {
-	constructor(options: KvStoreOptions) {
+export default class KvStore<T extends SessionStoreData> implements Store {
+	constructor(options: KvStoreOptions<T>) {
 		// The number of seconds for which the key should be visible before it expires. At least 60.
 		// (https://developers.cloudflare.com/api/operations/workers-kv-namespace-write-multiple-key-value-pairs#request-body)
 		if (options.ttl && options.ttl < 60 * 1000)
@@ -69,13 +69,13 @@ export default class KvStore implements Store {
 	 */
 	ttl: number;
 
-	async get(id: string): Promise<SessionStoreData | null> {
+	async get(id: string): Promise<T | null> {
 		const key = this.prefix + id;
 		const storeData = await this.client.get(key, { type: 'text' });
 		return storeData ? this.serializer.parse(storeData) : null;
 	}
 
-	async set(id: string, storeData: SessionStoreData, ttl: number): Promise<void> {
+	async set(id: string, storeData: T, ttl: number): Promise<void> {
 		if (ttl < 60 * 1000)
 			throw new Error(
 				'ttl must be at least 60 * 1000. please refer to https://developers.cloudflare.com/workers/runtime-apis/kv#expiration-ttlhttps://developers.cloudflare.com/api/operations/workers-kv-namespace-write-multiple-key-value-pairs#request-body.'

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import type { SessionCookieOptions,SessionStoreData } from 'svelte-kit-sessions';
+import type { SessionCookieOptions, SessionStoreData } from 'svelte-kit-sessions';
 import { Miniflare } from 'miniflare';
 import { KVNamespace } from '@cloudflare/workers-types';
 import KvStore from '../src/index.js';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import type { SessionCookieOptions } from 'svelte-kit-sessions';
+import type { SessionCookieOptions,SessionStoreData } from 'svelte-kit-sessions';
 import { Miniflare } from 'miniflare';
 import { KVNamespace } from '@cloudflare/workers-types';
 import KvStore from '../src/index.js';
@@ -34,7 +34,7 @@ const dumyCookieOptions: SessionCookieOptions = {
 describe('Test RedisStore', () => {
 	describe('client is KVNamespace', async () => {
 		const ns = (await mf.getKVNamespace('TEST_NAMESPACE')) as KVNamespace;
-		const store = new KvStore({ client: ns });
+		const store = new KvStore<SessionStoreData>({ client: ns });
 
 		beforeEach(async () => {
 			const ids = await ns.list();
@@ -69,6 +69,7 @@ describe('Test RedisStore', () => {
 				await store.set('sessionId', { cookie: dumyCookieOptions, data: { foo: 'foo' } }, Infinity);
 				const data = await store.get('sessionId');
 				expect(data).toEqual({ cookie: dumyCookieOptions, data: { foo: 'foo' } });
+				expect(data?.data.foo).toBe('foo');
 			});
 		});
 


### PR DESCRIPTION
this fix https://github.com/yutak23/svelte-kit-connect-cloudflare-kv/issues/1.

The current issue arises because `SessionData` types in `svelte-kit-sessions` and `svelte-kit-connect-cloudflare-kv` are not aligned, leading to type mismatches. By introducing a generic type parameter (`T`) in `KvStore`, we can explicitly specify the `SessionData` structure when using `KvStore`. This approach resolves type inconsistencies and ensures type safety, as `KvStore` and `svelte-kit-sessions` share the same `SessionData` definition. It also enhances flexibility, allowing different projects to define and use their own `SessionData` types seamlessly. 
